### PR TITLE
Pygame built ins

### DIFF
--- a/src/resourceful/__init__.py
+++ b/src/resourceful/__init__.py
@@ -1,9 +1,9 @@
 from .resource_manager import getResourceManager, ResourceManager  # noqa: F401
 
-# try:
-#     import pygame
+try:
+    import pygame  # noqa: F401
+    from .pygame import getImageManager, getSoundManager  # noqa: F401
 
-
-# except ImportError:
-#     # No pygame installed, no bonus functions for you.
-#     pass
+except ImportError:
+    # No pygame installed, no bonus functions for you.
+    pass

--- a/src/resourceful/__init__.py
+++ b/src/resourceful/__init__.py
@@ -1,49 +1,9 @@
-import os
-from pathlib import Path
-
 from .resource_manager import getResourceManager, ResourceManager  # noqa: F401
 
-try:
-    import pygame
+# try:
+#     import pygame
 
-    _image_manager = ResourceManager[pygame.Surface]("pygame_images")
-    _sound_manager = ResourceManager[pygame.Sound]("pygame_sounds")
-    _has_transparency: list[str] = [".png", ".gif"]
 
-    def _load_pygame_images(resource_location: os.PathLike | str) -> pygame.Surface:
-        location = Path(resource_location)
-        file_type = location.suffix
-        image = pygame.image.load(location)
-        if file_type in _has_transparency:
-            # Only want to call this on things that can contain transparency.
-            image.convert_alpha()
-        else:
-            image.convert()
-        return image
-
-    def _load_pygame_sounds(resource_location: os.PathLike | str) -> pygame.Sound:
-        location = Path(resource_location)
-        return pygame.mixer.Sound(location)
-
-    _image_manager.config(loader_helper=_load_pygame_images)
-    _sound_manager.config(loader_helper=_load_pygame_sounds)
-
-    def getImageManager():
-        """
-        Provides a pre-built resource manager specifically for loading images into
-        pygame Surfaces.
-        It is not managed by getResourceManager.
-        """
-        return _image_manager
-
-    def getSoundManager():
-        """
-        Provides a pre-built resource manager specifically for loading sounds for use in
-        pygame's mixer.
-        It is not managed by getResourceManager.
-        """
-        return _sound_manager
-
-except ImportError:
-    # No pygame installed, no bonus functions for you.
-    pass
+# except ImportError:
+#     # No pygame installed, no bonus functions for you.
+#     pass

--- a/src/resourceful/__init__.py
+++ b/src/resourceful/__init__.py
@@ -1,1 +1,49 @@
+import os
+from pathlib import Path
+
 from .resource_manager import getResourceManager, ResourceManager  # noqa: F401
+
+try:
+    import pygame
+
+    _image_manager = ResourceManager[pygame.Surface]("pygame_images")
+    _sound_manager = ResourceManager[pygame.Sound]("pygame_sounds")
+    _has_transparency: list[str] = [".png", ".gif"]
+
+    def _load_pygame_images(resource_location: os.PathLike | str) -> pygame.Surface:
+        location = Path(resource_location)
+        file_type = location.suffix
+        image = pygame.image.load(location)
+        if file_type in _has_transparency:
+            # Only want to call this on things that can contain transparency.
+            image.convert_alpha()
+        else:
+            image.convert()
+        return image
+
+    def _load_pygame_sounds(resource_location: os.PathLike | str) -> pygame.Sound:
+        location = Path(resource_location)
+        return pygame.mixer.Sound(location)
+
+    _image_manager.config(loader_helper=_load_pygame_images)
+    _sound_manager.config(loader_helper=_load_pygame_sounds)
+
+    def getImageManager():
+        """
+        Provides a pre-built resource manager specifically for loading images into
+        pygame Surfaces.
+        It is not managed by getResourceManager.
+        """
+        return _image_manager
+
+    def getSoundManager():
+        """
+        Provides a pre-built resource manager specifically for loading sounds for use in
+        pygame's mixer.
+        It is not managed by getResourceManager.
+        """
+        return _sound_manager
+
+except ImportError:
+    # No pygame installed, no bonus functions for you.
+    pass

--- a/src/resourceful/pygame/__init__.py
+++ b/src/resourceful/pygame/__init__.py
@@ -1,0 +1,1 @@
+from .pygame_prebuilt import getImageManager, getSoundManager  # noqa:F401

--- a/src/resourceful/pygame/pygame_prebuilt.py
+++ b/src/resourceful/pygame/pygame_prebuilt.py
@@ -7,15 +7,16 @@ import pygame
 
 _image_manager = ResourceManager[pygame.Surface]("pygame_images")
 _sound_manager = ResourceManager[pygame.Sound]("pygame_sounds")
-_has_transparency: list[str] = [".png", ".gif", ".lbm"]
+_has_transparency: list[str] = [".png", ".gif", ".lbm", ".webp", ".tga", ".xcf", ".qoi"]
+# I think that's all of them that can have alpha. I'll adjust as needed.
 
 
 def _load_pygame_images(resource_location: os.PathLike | str) -> pygame.Surface:
     location = Path(resource_location)
     file_type = location.suffix
     image = pygame.image.load(location)
-    if file_type in _has_transparency:
-        # Only want to call this on things that can contain transparency.
+    if file_type.lower() in _has_transparency:
+        # Only want to call this on things that have alpha channels.
         image.convert_alpha()
     else:
         image.convert()

--- a/src/resourceful/pygame/pygame_prebuilt.py
+++ b/src/resourceful/pygame/pygame_prebuilt.py
@@ -1,0 +1,49 @@
+import os
+from pathlib import Path
+
+from ..resource_manager import ResourceManager
+
+import pygame
+
+_image_manager = ResourceManager[pygame.Surface]("pygame_images")
+_sound_manager = ResourceManager[pygame.Sound]("pygame_sounds")
+_has_transparency: list[str] = [".png", ".gif", ".lbm"]
+
+
+def _load_pygame_images(resource_location: os.PathLike | str) -> pygame.Surface:
+    location = Path(resource_location)
+    file_type = location.suffix
+    image = pygame.image.load(location)
+    if file_type in _has_transparency:
+        # Only want to call this on things that can contain transparency.
+        image.convert_alpha()
+    else:
+        image.convert()
+    return image
+
+
+def _load_pygame_sounds(resource_location: os.PathLike | str) -> pygame.Sound:
+    location = Path(resource_location)
+    return pygame.mixer.Sound(location)
+
+
+_image_manager.config(loader_helper=_load_pygame_images)
+_sound_manager.config(loader_helper=_load_pygame_sounds)
+
+
+def getImageManager():
+    """
+    Provides a pre-built resource manager specifically for loading images into
+    pygame Surfaces.
+    It is not managed by getResourceManager.
+    """
+    return _image_manager
+
+
+def getSoundManager():
+    """
+    Provides a pre-built resource manager specifically for loading sounds for use in
+    pygame's mixer.
+    It is not managed by getResourceManager.
+    """
+    return _sound_manager


### PR DESCRIPTION
Adds an optional pre-built resource manager that is automatically imported with the package if pygame is importable.
Currently, this constitutes an image manager and sound manager.
Currently, the getters for these managers are imported at package level. If that turns out to be undesirable, I will change it.