### PR TITLE
Default resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ import resourceful
 MANAGER = resourceful.getResourceManager(<type>, "handle")
 ```
 
-Where \<type> is the class of resource to be managed.
+Where ```<type>``` is the class of resource to be managed.
 
 This will ensure that a resource manager for the given type and of the given handle exists.
 Handles are optional, but are useful for having resource managers with different loading behavior despite the same resource type, without increasing the complexity of the loader function.
@@ -222,6 +222,8 @@ It may be advisable to keep a separate module that contains all of your asset im
 
 ### Configuration
 
+#### Loader Functions
+
 Because resource managers are generic, they have no inherent knowledge of how to load any given resource. So, a loader function must be supplied.
 For example:
 ```python
@@ -245,6 +247,16 @@ They can do anything else you'd like, and can be a simple or as complicated as y
 Additionally, in an async-aware environment, you could have your loader begin a coroutine to download your asset, and return a default asset to tide things over until then, updating the asset upon completion.
 
 From there, the resource manager will take over, loading and supplying resources as needed by other parts of the program.
+
+#### Default Assets
+
+A default asset may be provided in the config function, allowing suppression of errors for loading failures by always having an option to fill in any blanks. If get() is called with a default value, it will override the manager-level default asset.
+
+None is considered a valid default, and should be handled appropriately. Simply Resourceful makes use of a sentinel value called NoDefault to determine that a default value does not exist or shouldn't be used.
+
+```python
+manager.config(default_asset=some_asset)
+```
 
 #### Preconfigured Options
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "simply_resourceful"
-version = "0.9.0"
+version = "1.0.0"
 authors = [
     { name="BetterBuiltFool", email="betterbuiltfool@gmail.com"}
 ]
@@ -18,4 +18,12 @@ classifiers = [
     "Topic :: Games/Entertainment",
     "Topic :: Software Development :: Libraries :: pygame",
     "Typing :: Typed"
+]
+
+[project.optional-dependencies]
+test = [
+    "pyfakefs >= 5.7.3",
+]
+pygame = [
+    "pygame_ce >= 2.5.2"
 ]

--- a/src/resourceful/__init__.py
+++ b/src/resourceful/__init__.py
@@ -1,4 +1,8 @@
-from .resource_manager import getResourceManager, ResourceManager  # noqa: F401
+from .resource_manager import (  # noqa: F401
+    getResourceManager,
+    ResourceManager,
+    NoDefault,
+)
 
 try:
     import pygame  # noqa: F401

--- a/src/resourceful/__init__.py
+++ b/src/resourceful/__init__.py
@@ -6,7 +6,7 @@ from .resource_manager import (  # noqa: F401
 
 try:
     import pygame  # noqa: F401
-    from .pygame import getImageManager, getSoundManager  # noqa: F401
+    from .pygame import getImageManager, getSoundManager, DEFAULT_SURFACE  # noqa: F401
 
 except ImportError:
     # No pygame installed, no bonus functions for you.

--- a/src/resourceful/pygame/__init__.py
+++ b/src/resourceful/pygame/__init__.py
@@ -1,1 +1,5 @@
-from .pygame_prebuilt import getImageManager, getSoundManager  # noqa:F401
+from .pygame_prebuilt import (  # noqa:F401
+    getImageManager,
+    getSoundManager,
+    DEFAULT_SURFACE,
+)

--- a/src/resourceful/pygame/pygame_prebuilt.py
+++ b/src/resourceful/pygame/pygame_prebuilt.py
@@ -11,7 +11,8 @@ _has_transparency: list[str] = [".png", ".gif", ".lbm", ".webp", ".tga", ".xcf",
 # I think that's all of them that can have alpha. I'll adjust as needed.
 
 
-DEFAULT_SURFACE = pygame.Surface((16, 16))
+_default_scale_factor = 8
+DEFAULT_SURFACE = pygame.Surface((_default_scale_factor * 4, _default_scale_factor * 4))
 """
 A 16x16 black and fuchsia checkerboard pattern to serve as a default image.
 """
@@ -23,7 +24,12 @@ for i in range(4):
             pygame.draw.rect(
                 DEFAULT_SURFACE,
                 pygame.Color("fuchsia"),
-                pygame.Rect(4 * i, 4 * j, 4, 4),
+                pygame.Rect(
+                    _default_scale_factor * i,
+                    _default_scale_factor * j,
+                    _default_scale_factor,
+                    _default_scale_factor,
+                ),
             )
 
 

--- a/src/resourceful/pygame/pygame_prebuilt.py
+++ b/src/resourceful/pygame/pygame_prebuilt.py
@@ -11,6 +11,22 @@ _has_transparency: list[str] = [".png", ".gif", ".lbm", ".webp", ".tga", ".xcf",
 # I think that's all of them that can have alpha. I'll adjust as needed.
 
 
+DEFAULT_SURFACE = pygame.Surface((16, 16))
+"""
+A 16x16 black and fuchsia checkerboard pattern to serve as a default image.
+"""
+DEFAULT_SURFACE.fill(pygame.Color("black"))
+for i in range(4):
+    for j in range(4):
+        if i % 2 == j % 2:
+            # This creates a checkerboard pattern
+            pygame.draw.rect(
+                DEFAULT_SURFACE,
+                pygame.Color("fuchsia"),
+                pygame.Rect(4 * i, 4 * j, 4, 4),
+            )
+
+
 def _load_pygame_images(resource_location: os.PathLike | str) -> pygame.Surface:
     location = Path(resource_location)
     file_type = location.suffix
@@ -28,7 +44,7 @@ def _load_pygame_sounds(resource_location: os.PathLike | str) -> pygame.Sound:
     return pygame.mixer.Sound(location)
 
 
-_image_manager.config(loader_helper=_load_pygame_images)
+_image_manager.config(loader_helper=_load_pygame_images, default_asset=DEFAULT_SURFACE)
 _sound_manager.config(loader_helper=_load_pygame_sounds)
 
 

--- a/src/resourceful/resource_manager.py
+++ b/src/resourceful/resource_manager.py
@@ -9,6 +9,9 @@ from typing import Any, TypeVar
 
 T = TypeVar("T")
 
+# Sentinel value for defining no default object, so None may be used as a valid option.
+No_Default = object()
+
 
 class ResourceManager[T]:
     _instances: dict[type[T], dict[str, ResourceManager]] = {}

--- a/src/resourceful/resource_manager.py
+++ b/src/resourceful/resource_manager.py
@@ -21,8 +21,13 @@ class ResourceManager[T]:
         self.handle = handle
         self.cache: dict[str, T] = {}
         self.resource_locations: dict[str, Path] = {}
+        self.default_asset: T | None | No_Default_Type = No_Default
 
-    def config(self, loader_helper: Callable | None = None) -> None:
+    def config(
+        self,
+        loader_helper: Callable | None = None,
+        default_asset: T | None | No_Default_Type = No_Default,
+    ) -> None:
         """
         Modifies the resource manager's behavior per the specified parameters.
 
@@ -31,6 +36,8 @@ class ResourceManager[T]:
         """
         if loader_helper:
             self._asset_loader = loader_helper
+        if default_asset is not No_Default:
+            self.default_asset = default_asset
 
     def import_asset(self, asset_handle: str, resource_location: Any) -> None:
         """

--- a/src/resourceful/resource_manager.py
+++ b/src/resourceful/resource_manager.py
@@ -10,6 +10,7 @@ from typing import Any, TypeVar
 T = TypeVar("T")
 
 # Sentinel value for defining no default object, so None may be used as a valid option.
+No_Default_Type = TypeVar("No_Default_Type")
 No_Default = object()
 
 
@@ -157,7 +158,9 @@ class ResourceManager[T]:
         # Otherwise, force the loaded asset to take on the new asset's attributes.
         old_asset.__dict__ = asset.__dict__
 
-    def get(self, asset_handle: str, default: T | None = None) -> T:
+    def get(
+        self, asset_handle: str, default: T | None | No_Default_Type = No_Default
+    ) -> T:
         """
         Gets the asset of the requested handle. Loads the asset if it hasn't been
         already.
@@ -167,8 +170,8 @@ class ResourceManager[T]:
         :param asset_handle: Name of the asset to be gotten
         :param default: Item returned if the asset is unavailable
         :raises KeyError: Raised if handle is not found or fails to load,
-        and no default is given
-        :return: The (loaded) instance of the asset, or the default.
+        and no default is given or otherwise available.
+        :return: The (loaded) instance of the asset, or the default if available.
         """
         if asset_handle not in self.resource_locations:
             if default is None:

--- a/src/resourceful/resource_manager.py
+++ b/src/resourceful/resource_manager.py
@@ -19,19 +19,47 @@ class SentinelMeta(type):
         return False
 
 
-# Sentinel value for defining no default object, so None may be used as a valid option.
 class NoDefault(metaclass=SentinelMeta):
+    """
+    Sentinel class to serve as a comparison for default asset parameters, allowing None
+    to be a valid asset value.
+    """
+
     pass
 
 
 class ResourceManager[T]:
+    """
+    A class for that tracks resources of a given type, ascribing handles to them for
+    easy reference, and lazy loading them when requested.
+    """
+
     _instances: dict[type[T], dict[str, ResourceManager]] = {}
 
     def __init__(self, handle: str) -> None:
+        """
+        Create an asset manager for the given type, with the given handle.
+
+        :param type: Type of asset to be managed.
+        :param handle: Name for the asset manager, so multiple managers for the same
+        resource type can exist.
+        """
         self.handle = handle
+        """
+        Name of the Resource Manager
+        """
         self.cache: dict[str, T] = {}
+        """
+        Dictionary caching all of the loaded assets with their handles.
+        """
         self.resource_locations: dict[str, Path] = {}
+        """
+        Dictionary holding needed loading data for each asset.
+        """
         self.default_asset: T | None | NoDefault = NoDefault
+        """
+        Default asset to be supplied if requested asset cannot be loaded.
+        """
 
     def config(
         self,

--- a/src/resourceful/resource_manager.py
+++ b/src/resourceful/resource_manager.py
@@ -52,7 +52,7 @@ class ResourceManager[T]:
         """
         Dictionary caching all of the loaded assets with their handles.
         """
-        self.resource_locations: dict[str, Path] = {}
+        self.resource_locations: dict[str, Any] = {}
         """
         Dictionary holding needed loading data for each asset.
         """

--- a/src/resourceful/resource_manager.py
+++ b/src/resourceful/resource_manager.py
@@ -211,7 +211,7 @@ class ResourceManager[T]:
             asset = self._asset_loader(self.resource_locations.get(asset_handle))
             if asset is None:
                 # Last chance to get an asset
-                if default is None:
+                if default is NoDefault:
                     raise KeyError(f"Resource '{asset_handle}' failed to load.")
                 asset = default
             self.cache[asset_handle] = asset


### PR DESCRIPTION
Allows Resource Managers to accept a default value to be supplied whenever an asset is requested but not available.
This default value may be overridden by a method-level default value.